### PR TITLE
reformat how tags are added to a link

### DIFF
--- a/utils/linksHandler.test.ts
+++ b/utils/linksHandler.test.ts
@@ -76,7 +76,7 @@ describe('Link Generation Module', () => {
     expect(url.searchParams.get('~channel')).toBe('espn')
     expect(url.searchParams.get('market_selection_id[0]')).toBe('m1')
     expect(url.searchParams.get('odds_numerator[1]')).toBe('3')
-    expect(url.searchParams.get('tags[0]')).toBe('sports')
+    expect(url.searchParams.get('tags')).toBe('sports')
   })
 
   it('should return the most recent link', () => {

--- a/utils/linksHandler.ts
+++ b/utils/linksHandler.ts
@@ -118,8 +118,8 @@ function generateLink({
     url.searchParams.append('~channel', channel.label)
   }
 
-  tags?.forEach((item, index) => {
-    url.searchParams.append(`tags[${index}]`, item.label)
+  tags?.forEach(item => {
+    url.searchParams.append(`tags`, item.label)
   })
 
   const generatedLink = {


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->

Previously we were adding the `tags` parameters to the URL in an array format (e.g `www.someurl.com/?tags[0]=tag-1&tags[1]=tag-2`)

This was causing Branch to have issues parsing, therefore we are moving to the following format (`www.someurl.com/?tags=tag-1&tags=tag-2`) which Branch should be able to parse properly


## Changes*

1. Just a quick update to how the link generation function works in linksHandler.ts

## How to check the feature
<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->


## Reference
<!-- Any helpful information for understanding the PR. -->
